### PR TITLE
fix: resolve __dirname in ESM and clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Code, Bookmark, FileText, Clipboard } from 'lucide-react'

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- derive __dirname from import.meta.url in Vite config
- remove unused React import from App
- add gitignore for node_modules

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688fc5848140832f8083921e312ab685